### PR TITLE
Update simple-share-buttons-adder.php

### DIFF
--- a/simple-share-buttons-adder.php
+++ b/simple-share-buttons-adder.php
@@ -479,6 +479,7 @@ GNU General Public License for more details.
 										.ssba img		
 										{ 	
 											width: ' . $arrSettings['ssba_size'] . 'px !important;
+											height: auto;
 											padding: ' . $arrSettings['ssba_padding'] . 'px;
 											border:  0;
 											box-shadow: none !important;


### PR DESCRIPTION
Added height:auto; to correct image distortion with some WordPress Themes.
