### PR TITLE
Add buttons to content later

### DIFF
--- a/simple-share-buttons-adder.php
+++ b/simple-share-buttons-adder.php
@@ -768,13 +768,13 @@ GNU General Public License for more details.
 	}
 
 	// add share buttons to content	
-	add_filter( 'the_content', 'show_share_buttons');	
+	add_filter( 'the_content', 'show_share_buttons', 99 );	
 	
 	// if we wish to add to excerpts
 	if($arrSettings['ssba_excerpts'] == 'Y') {
 		
 		// add a hook
-		add_filter( 'the_excerpt', 'show_share_buttons');
+		add_filter( 'the_excerpt', 'show_share_buttons', 99 );
 	}
 
 	// shortcode for adding buttons


### PR DESCRIPTION
Since the share buttons are always at the end of the content, I pushed the priority to 99 so that it's always the last filter fired. This would solve a conflict I'm having with another plugin I'm working on that adds content at the same priority level as `ssba` but after it, which looks wrong.
